### PR TITLE
Remove dead code that prevents easy installation in Dockerfile without access to CUDA runtime

### DIFF
--- a/csrc/flashfftconv/setup.py
+++ b/csrc/flashfftconv/setup.py
@@ -3,11 +3,6 @@ from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
 import subprocess
 
-def get_last_arch_torch():
-    arch = torch.cuda.get_arch_list()[-1]
-    print(f"Found arch: {arch} from existing torch installation")
-    return arch
-
 def get_cuda_bare_metal_version(cuda_dir):
     raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True)
     output = raw_output.split()
@@ -24,11 +19,7 @@ def append_nvcc_threads(nvcc_extra_args):
         return nvcc_extra_args + ["--threads", "4"]
     return nvcc_extra_args
 
-arch = get_last_arch_torch()
-# [MP] make install more flexible here
-sm_num = arch[-2:]
 cc_flag = ['--generate-code=arch=compute_80,code=compute_80']
-
 
 setup(
     name='monarch_cuda',


### PR DESCRIPTION
Hi Dan & Hermann,

I noticed that including flash-fft-conv in a docker image is very difficult. As it requires access to a CUDA runtime instance during compilation. As noticed by [Jacob Huffman](https://research.nvidia.com/person/jacob-huffman) the main issue is some dead code that seems not to be used anywhere. 

This PR removes that code, allowing to include flash-fft-conv without need to CUDA runtime instances. This makes it very simple to include flash-fft-conv in Docker images. 

Best,

David